### PR TITLE
upgrade buildToolsVersion to '26.0.3'

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    buildToolsVersion '26.0.3'
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Hello @aloisdeniel.

~I'm currently using ur lib to geocoding some coordinates.
But recently after some upgrade, my project start to broken for some gradle version problem with geocoder, so i decided to upgrade geocoder following this [tutorial](https://github.com/flutter/flutter/wiki/Upgrading-Flutter-projects-to-Gradle-4.1-and-Android-Studio-Gradle-plugin-3.0.1).
I really don't know if i did this right, any way, if u can review/merge this, I will appreciate it.~

Thanks and sorry for my bad english.

Edit.
Sorry, my mistake, just bumping buildToolsVersion to '26.0.3' make it works.