### PR TITLE
Migration to AndroidX, add support for language in GoogleGeocoding and fix issue with @UiThread

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.3.0'
     }
 }
 
@@ -26,15 +26,12 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '28.0.3'
+    compileSdkVersion 28
+    //buildToolsVersion '28.0.3'
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 25
-        versionCode 1
-        versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 25
-//    buildToolsVersion '25.0.3'
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         minSdkVersion 16

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+//    buildToolsVersion '25.0.3'
 
     defaultConfig {
         minSdkVersion 16

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -15,8 +15,8 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    compileSdkVersion 28
+    //buildToolsVersion '25.0.3'
 
     lintOptions {
         disable 'InvalidPackage'
@@ -26,10 +26,10 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.yourcompany.geocoderexample"
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -46,7 +46,7 @@ flutter {
 }
 
 dependencies {
-    androidTestCompile 'com.android.support:support-annotations:25.4.0'
-    androidTestCompile 'com.android.support.test:runner:0.5'
-    androidTestCompile 'com.android.support.test:rules:0.5'
+    androidTestCompile 'androidx.annotation:annotation:1.0.1'
+    androidTestCompile 'androidx.test:runner:1.1.1'
+    androidTestCompile 'androidx.test:rules:1.1.1'
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.3.0'
     }
 }
 

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip

--- a/lib/geocoder.dart
+++ b/lib/geocoder.dart
@@ -6,5 +6,5 @@ export 'model.dart';
 
 class Geocoder {
   static final Geocoding local = LocalGeocoding();
-  static Geocoding google(String apiKey) => GoogleGeocoding(apiKey);
+  static Geocoding google(String apiKey, { String language }) => GoogleGeocoding(apiKey, language: language);
 }

--- a/lib/services/distant_google.dart
+++ b/lib/services/distant_google.dart
@@ -12,15 +12,16 @@ class GoogleGeocoding implements Geocoding {
   static const _host = 'https://maps.google.com/maps/api/geocode/json';
 
   final String apiKey;
+  final String language;
 
   final HttpClient _httpClient;
 
-  GoogleGeocoding(this.apiKey) :
+  GoogleGeocoding(this.apiKey, { this.language }) :
     _httpClient = HttpClient(),
     assert(apiKey != null, "apiKey must not be null");
 
   Future<List<Address>> findAddressesFromCoordinates(Coordinates coordinates) async  {
-    final url = '$_host?key=$apiKey&latlng=${coordinates.latitude},${coordinates.longitude}';
+    final url = '$_host?key=$apiKey${language != null ? '&language='+language : ''}&latlng=${coordinates.latitude},${coordinates.longitude}';
     return _send(url);
   }
 

--- a/lib/services/distant_google.dart
+++ b/lib/services/distant_google.dart
@@ -31,12 +31,12 @@ class GoogleGeocoding implements Geocoding {
   }
 
   Future<List<Address>> _send(String url) async {
-    print("Sending $url...");
+    //print("Sending $url...");
     final uri = Uri.parse(url);
     final request = await this._httpClient.getUrl(uri);
     final response = await request.close();
     final responseBody = await response.transform(utf8.decoder).join();
-    print("Received $responseBody...");
+    //print("Received $responseBody...");
     var data = jsonDecode(responseBody);
 
     var results = data["results"];


### PR DESCRIPTION
Hello,
I am migrating the code of my application to AndroidX, so this is a proposal for migration to AndroidX for flutter_geocoder. (https://github.com/aloisdeniel/flutter_geocoder/issues/14) I also removed buildToolsVersion, we don't need it anymore.

Edit : I also propose the following changes:
- add support for language in GoogleGeocoding
- fix issue with "Methods marked with @UiThread must be executed on the main thread" (to support the latest flutter engine version, at least the version 1.6.0 of Flutter). I mean this allows to fix the issue https://github.com/aloisdeniel/flutter_geocoder/issues/18 