### PR TITLE
Handle cases where native API is present but unavailable

### DIFF
--- a/android/src/main/java/com/aloisdeniel/geocoder/GeocoderPlugin.java
+++ b/android/src/main/java/com/aloisdeniel/geocoder/GeocoderPlugin.java
@@ -76,6 +76,9 @@ public class GeocoderPlugin implements MethodCallHandler {
         try {
           plugin.assertPresent();
           List<Address> addresses = geocoder.getFromLocationName(address, 20);
+	      if (addresses.size() == 0) {
+	        throw new NotAvailableException();
+	      }
           result.success(createAddressMapList(addresses));
         }
         catch(IOException ex) {
@@ -106,6 +109,9 @@ public class GeocoderPlugin implements MethodCallHandler {
         try {
           plugin.assertPresent();
           List<Address> addresses = geocoder.getFromLocation(latitude, longitude, 20);
+	      if (addresses.size() == 0) {
+  		    throw new NotAvailableException();
+	      }
           result.success(createAddressMapList(addresses));
         } catch (IOException ex) {
           result.error("failed", ex.toString(), null);


### PR DESCRIPTION
The isPresent test only lets us know whether the native getFromLocation and getFromLocationName APIs are available, but doesn't say anything about the APIs ability to return results. In cases where either of these APIs fail, despite being present, an empty list is returned, which is then passed off as a success to the higher levels. From the flutter client side, this then results in a null gRPC call, despite having otherwise succeeded at the lower levels and consequently having failed to raise any exceptions.

The simplest solution, and the one used here, is to test the number of addresses returned by the native APIs, and in cases where this is 0, simply throw a NotAvailableException.

A more elaborate solution would be to check the number of addresses returned, and fall back on an alternative method of lookup, but this is left as future work.

This should also provide an improvement to the situation observed in issue #19 