### PR TITLE
Prepare for Uint8List SDK breaking change

### DIFF
--- a/lib/services/distant_google.dart
+++ b/lib/services/distant_google.dart
@@ -35,7 +35,7 @@ class GoogleGeocoding implements Geocoding {
     final uri = Uri.parse(url);
     final request = await this._httpClient.getUrl(uri);
     final response = await request.close();
-    final responseBody = await response.transform(utf8.decoder).join();
+    final responseBody = await utf8.decoder.bind(response).join();
     print("Received $responseBody...");
     var data = jsonDecode(responseBody);
 


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpClientResponse`
to implement `Stream<Uint8List>` rather than implementing
`Stream<List<int>>`.

This forwards-compatible change updates calls to
`Stream.transform(StreamTransformer)` to instead call the
functionally equivalent `StreamTransformer.bind(Stream)`
API, which puts the stream in a covariant position and
thus causes the SDK change to be non-breaking.

https://github.com/dart-lang/sdk/issues/36900
