### PR TITLE
add prefered result language argument

### DIFF
--- a/ios/Classes/GeocoderPlugin.m
+++ b/ios/Classes/GeocoderPlugin.m
@@ -27,14 +27,25 @@
   if ([@"findAddressesFromCoordinates" isEqualToString:call.method]) {
       NSNumber *longitude = call.arguments[@"longitude"];
       NSNumber *latitude = call.arguments[@"latitude"];
+      NSString *language = call.arguments[@"language"];
       CLLocation * location = [[CLLocation alloc] initWithLatitude:latitude.doubleValue longitude:longitude.doubleValue];
       [self initializeGeocoder];
-      [self.geocoder reverseGeocodeLocation:location completionHandler:^(NSArray *placemarks, NSError *error) {
-          if (error) {
-              return result(error.flutterError);
-          }
-          result([self placemarksToDictionary:placemarks]);
-      }];
+      if (language != (id)[NSNull null] && @available(iOS 11.0, *)) {
+          NSLocale *locale = [[NSLocale alloc] initWithLocaleIdentifier:language];
+          [self.geocoder reverseGeocodeLocation:location preferredLocale:locale completionHandler:^(NSArray *placemarks, NSError *error) {
+              if (error) {
+                  return result(error.flutterError);
+              }
+              result([self placemarksToDictionary:placemarks]);
+          }];
+      } else {
+          [self.geocoder reverseGeocodeLocation:location completionHandler:^(NSArray *placemarks, NSError *error) {
+              if (error) {
+                  return result(error.flutterError);
+              }
+              result([self placemarksToDictionary:placemarks]);
+          }];
+      }
   }
   else if ([@"findAddressesFromQuery" isEqualToString:call.method]) {
       NSString *address = call.arguments[@"address"];

--- a/lib/geocoder.dart
+++ b/lib/geocoder.dart
@@ -6,5 +6,6 @@ export 'model.dart';
 
 class Geocoder {
   static final Geocoding local = LocalGeocoding();
+  static Geocoding withLanguage(String language) => LocalGeocoding(language: language);
   static Geocoding google(String apiKey, { String language }) => GoogleGeocoding(apiKey, language: language);
 }

--- a/lib/services/local.dart
+++ b/lib/services/local.dart
@@ -7,10 +7,18 @@ import 'package:geocoder/services/base.dart';
 
 /// Geocoding and reverse geocoding through built-lin local platform services.
 class LocalGeocoding implements Geocoding {
+  final String language;
+
+  LocalGeocoding({ this.language });
+
   static const MethodChannel _channel = MethodChannel('github.com/aloisdeniel/geocoder');
 
   Future<List<Address>> findAddressesFromCoordinates(Coordinates coordinates) async  {
-    Iterable addresses = await _channel.invokeMethod('findAddressesFromCoordinates', coordinates.toMap());
+    Iterable addresses = await _channel.invokeMethod('findAddressesFromCoordinates', {
+      "latitude": coordinates.latitude,
+      "longitude": coordinates.longitude,
+      "language": language,
+    });
     return addresses.map((x) => Address.fromMap(x)).toList();
   }
 


### PR DESCRIPTION
Hello!
This PR allows to set result language like that:
```
final addresses = await Geocoder.withLanguage("en")
            .findAddressesFromCoordinates(coordinates);
```

Manually tested on both platforms with `.local` and with `.withLanguage`.