### PR TITLE
Add viewport to the address

### DIFF
--- a/lib/model.dart
+++ b/lib/model.dart
@@ -30,6 +30,8 @@ class Address {
   /// The geographic coordinates.
   final Coordinates coordinates;
 
+  final List<Coordinates> viewport;
+
   /// The formatted address with all lines.
   final String addressLine;
 
@@ -63,7 +65,20 @@ class Address {
   /// The sub-thoroughfare name of the address
   final String subThoroughfare;
 
-  Address({this.coordinates, this.addressLine, this.countryName, this.countryCode, this.featureName, this.postalCode, this.adminArea, this.subAdminArea, this.locality, this.subLocality, this.thoroughfare, this.subThoroughfare});
+  Address(
+    {this.coordinates,
+    this.viewport,
+    this.addressLine,
+    this.countryName,
+    this.countryCode,
+    this.featureName,
+    this.postalCode,
+    this.adminArea,
+    this.subAdminArea,
+    this.locality,
+    this.subLocality,
+    this.thoroughfare,
+    this.subThoroughfare});
 
   /// Creates an address from a map containing its properties.
   Address.fromMap(Map map) :
@@ -78,7 +93,11 @@ class Address {
         this.adminArea = map["adminArea"],
         this.subAdminArea = map["subAdminArea"],
         this.thoroughfare = map["thoroughfare"],
-        this.subThoroughfare = map["subThoroughfare"];
+        this.subThoroughfare = map["subThoroughfare"],
+        this.viewport = map["viewport"]
+          .toList()
+          .map<Coordinates>((coordinates) => Coordinates.fromMap(coordinates))
+          .toList();
 
   /// Creates a map from the address properties.
   Map toMap() => {

--- a/lib/services/distant_google.dart
+++ b/lib/services/distant_google.dart
@@ -79,7 +79,7 @@ class GoogleGeocoding implements Geocoding {
     var northeast = viewport["northeast"];
     var southwest = viewport["southwest"];
 
-    if (northeast == null || southwest == null )
+    if (northeast == null || southwest == null)
       return null;
 
     return [

--- a/lib/services/distant_google.dart
+++ b/lib/services/distant_google.dart
@@ -64,11 +64,42 @@ class GoogleGeocoding implements Geocoding {
     };
   }
 
+  List<Map> _convertViewport(dynamic geometry) {
+    if (geometry == null)
+      return null;
+
+    var location = geometry["location"];
+    if (location == null)
+      return null;
+
+    var viewport = geometry["viewport"];
+    if (viewport == null)
+      return null;
+
+    var northeast = viewport["northeast"];
+    var southwest = viewport["southwest"];
+
+    if (northeast == null || southwest == null )
+      return null;
+
+    return [
+      {
+        "latitude": northeast["lat"],
+        "longitude": northeast["lng"],
+      },
+      {
+        "latitude": southwest["lat"],
+        "longitude": southwest["lng"],
+      },
+    ];
+  }
+
   Map _convertAddress(dynamic data) {
 
     Map result = Map();
 
     result["coordinates"] = _convertCoordinates(data["geometry"]);
+    result["viewport"] = _convertViewport(data["geometry"]);
     result["addressLine"] = data["formatted_address"];
 
     var addressComponents = data["address_components"];


### PR DESCRIPTION
hey @aloisdeniel! When doing geocoding and showing the result on the map, it's very useful to know the bounding box of the place, especially when not looking up something very exact (e.g. a national park). Google provides this in the viewport property:

![pl](https://user-images.githubusercontent.com/828897/77224715-55e00a80-6b60-11ea-9c6e-bd437d88d959.png)

I'm adding this to the Google version of the geocoder - not sure how to do it for the local one (and I don't really need it for my personal project).

Let me know what you think of this PR.