### PR TITLE
Added option to pass headers for requests to Google APIs

### DIFF
--- a/lib/geocoder.dart
+++ b/lib/geocoder.dart
@@ -6,5 +6,12 @@ export 'model.dart';
 
 class Geocoder {
   static final Geocoding local = LocalGeocoding();
-  static Geocoding google(String apiKey, { String language }) => GoogleGeocoding(apiKey, language: language);
+  static Geocoding google(String apiKey,
+          {String language,
+          Map<String, Object> headers,
+          bool preserveHeaderCase = false}) =>
+      GoogleGeocoding(apiKey,
+          language: language,
+          headers: headers,
+          preserveHeaderCase: preserveHeaderCase);
 }

--- a/lib/services/distant_google.dart
+++ b/lib/services/distant_google.dart
@@ -8,20 +8,24 @@ import 'package:geocoder/services/base.dart';
 
 /// Geocoding and reverse geocoding through requests to Google APIs.
 class GoogleGeocoding implements Geocoding {
-
   static const _host = 'https://maps.google.com/maps/api/geocode/json';
 
   final String apiKey;
   final String language;
+  final Map<String, Object> headers;
+  final bool preserveHeaderCase;
 
   final HttpClient _httpClient;
 
-  GoogleGeocoding(this.apiKey, { this.language }) :
-    _httpClient = HttpClient(),
-    assert(apiKey != null, "apiKey must not be null");
+  GoogleGeocoding(this.apiKey,
+      {this.language, this.headers, this.preserveHeaderCase = false})
+      : _httpClient = HttpClient(),
+        assert(apiKey != null, "apiKey must not be null");
 
-  Future<List<Address>> findAddressesFromCoordinates(Coordinates coordinates) async  {
-    final url = '$_host?key=$apiKey${language != null ? '&language='+language : ''}&latlng=${coordinates.latitude},${coordinates.longitude}';
+  Future<List<Address>> findAddressesFromCoordinates(
+      Coordinates coordinates) async {
+    final url =
+        '$_host?key=$apiKey${language != null ? '&language=' + language : ''}&latlng=${coordinates.latitude},${coordinates.longitude}';
     return _send(url);
   }
 
@@ -35,6 +39,11 @@ class GoogleGeocoding implements Geocoding {
     //print("Sending $url...");
     final uri = Uri.parse(url);
     final request = await this._httpClient.getUrl(uri);
+    if (headers != null) {
+      headers.forEach((key, value) {
+        request.headers.add(key, value, preserveHeaderCase: preserveHeaderCase);
+      });
+    }
     final response = await request.close();
     final responseBody = await utf8.decoder.bind(response).join();
     //print("Received $responseBody...");


### PR DESCRIPTION
This is a fix for Issue [31](https://github.com/aloisdeniel/flutter_geocoder/issues/31)

Users can now pass headers to `Geocoder.google`. 

If the user has Restrictions applied to the API keys, then we have to pass headers with the HTTP request.
Setting the following headers fixes the issue

For Android
`X-Android-Package: <YOUR PACKAGE NAME>`
and
`X-Android-Cert: <YOUR CERT SHA1>`

For iOS
`X-Ios-Bundle-Identifier: <YOUR PACKAGE NAME>`

You can get your android Cert SHA1 using the following code

```
class AppInfo {
  static const _platform = const MethodChannel('google_map_location_picker');
  static Future<String> getSigningCertSha1(String packageName) async {
      return await _platform.invokeMethod(
          'getSigningCertSha1', packageName);
    
  }
}

```


