### PR TITLE
Added web support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,4 +27,9 @@ android {
     defaultConfig {
         minSdkVersion 16
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }

--- a/lib/geocoder.dart
+++ b/lib/geocoder.dart
@@ -6,14 +6,7 @@ export 'model.dart';
 
 class Geocoder {
   static final Geocoding local = LocalGeocoding();
-  static Geocoding google(
-    String apiKey, {
-    String? language,
-    Map<String, String>? headers,
-    bool preserveHeaderCase = false,
-  }) =>
-      GoogleGeocoding(apiKey,
-          language: language,
-          headers: headers,
-          preserveHeaderCase: preserveHeaderCase);
+  static Geocoding google(String apiKey,
+          {String? language, Map<String, String>? headers}) =>
+      GoogleGeocoding(apiKey, language: language, headers: headers);
 }

--- a/lib/geocoder.dart
+++ b/lib/geocoder.dart
@@ -9,7 +9,7 @@ class Geocoder {
   static Geocoding google(
     String apiKey, {
     String? language,
-    Map<String, Object>? headers,
+    Map<String, String>? headers,
     bool preserveHeaderCase = false,
   }) =>
       GoogleGeocoding(apiKey,

--- a/lib/services/distant_google.dart
+++ b/lib/services/distant_google.dart
@@ -13,13 +13,11 @@ class GoogleGeocoding implements Geocoding {
   final String apiKey;
   final String? language;
   final Map<String, String>? headers;
-  final bool preserveHeaderCase;
 
   GoogleGeocoding(
     this.apiKey, {
     this.language,
     this.headers,
-    this.preserveHeaderCase = false,
   });
 
   Future<List<Address>> findAddressesFromCoordinates(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  http: ^0.13.3
+  http: ^0.13.4
 
 flutter:
   plugin:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,11 +4,12 @@ version: 0.3.0
 homepage: https://github.com/aloisdeniel/flutter_geocoder
 
 environment:
-    sdk: ">=2.12.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
+  http: ^0.13.3
 
 flutter:
   plugin:


### PR DESCRIPTION
Hi, This pull request adds web support. 
Instead of using dart's inbuilt `HttpClient()`, which do not support the web, I've added `http` package which supports all the platform including the web, giving us the ability to use this package for the web. The only requirement for the web is to use `Geocoder.google(...)` and NOT `Geocoder.local(...)`.

